### PR TITLE
Fix up

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ test:
 about:
   home: https://github.com/mahmoudimus/nose-timer
   license: MIT or BSD 4-Clause
+  license_file: LICENSE
   summary: A timer plugin for nosetests.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: nose-timer-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/n/nose-timer/nose-timer-{{ version }}.tar.gz
-  md5: 739fb9901de979e9f52ecdca272c105d
+  sha256: 1253a20295d9c75a9f87b8c898d9b6003ae99d5d0fe95c3dd978954329b0919f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1253a20295d9c75a9f87b8c898d9b6003ae99d5d0fe95c3dd978954329b0919f
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,6 @@ requirements:
   build:
     - python
     - setuptools
-    - nose
-    - termcolor
 
   run:
     - python


### PR DESCRIPTION
* Use `sha256` (instead of `md5`).
* Drop unneeded dependencies from `build`.
* Package the license file.
* Bump the build number to 1.