### PR TITLE
Add patch to drop ordereddict

### DIFF
--- a/recipe/PR_84.diff
+++ b/recipe/PR_84.diff
@@ -1,0 +1,28 @@
+diff --git nosetimer/plugin.py nosetimer/plugin.py
+index ef28e11..d093a51 100644
+--- nosetimer/plugin.py
++++ nosetimer/plugin.py
+@@ -12,10 +12,7 @@
+ except ImportError:
+     import queue as Queue
+ 
+-try:
+-    from collections import OrderedDict
+-except ImportError:
+-    from ordereddict import OrderedDict
++from collections import OrderedDict
+ 
+ 
+ # define constants
+diff --git setup.py setup.py
+index 6a55b82..d249325 100755
+--- setup.py
++++ setup.py
+@@ -27,7 +27,6 @@
+     install_requires=[
+         'nose',
+         'termcolor',
+-        'ordereddict',
+     ],
+     license='MIT',
+     entry_points={

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - PR_84.diff
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,13 @@ source:
   fn: nose-timer-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/n/nose-timer/nose-timer-{{ version }}.tar.gz
   sha256: b76baab514aff39ac567455aaecd63b881127f922e9632b1f814f96575f562e8
+  patches:
+    ############################################################
+    # Drop unneeded ordereddict dependency.                    #
+    #                                                          #
+    # xref: https://github.com/mahmoudimus/nose-timer/pull/84  #
+    ############################################################
+    - PR_84.diff
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,9 @@ test:
   imports:
     - nosetimer
 
+  commands:
+    - nosetests --with-timer
+
 about:
   home: https://github.com/mahmoudimus/nose-timer
   license: MIT


### PR DESCRIPTION
Seems an unneeded dependency on `ordereddict` is causing issues with using `nose-timer`. This adds a patch to remove that dependency and a CLI test to verify the correct behavior has been restored.